### PR TITLE
Add clarification text for average times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 
 *.pem
+node_modules

--- a/src/diningin.tweaks.js
+++ b/src/diningin.tweaks.js
@@ -226,8 +226,16 @@ function averageDeliveryTimes() {
 
 			var time = restaurantsTimes[data2.rl];
 			if (time) {
-				var timeDisplay = $('<div>' + time.substring(0,5) + '<div>')
-					.css('padding-top', '15px')
+				var timeLabel = $('<div>Average Time:</div>')
+					.css('margin-top', '8px')
+					.css('border-top', '1px solid lightgray')
+					.css('padding-top', '8px')
+					.css('font-size', 12);
+				$item.append(timeLabel);
+				
+				var timeString = time.split(":").slice(0,2).join(":");
+				var timeDisplay = $('<div>' + timeString + '<div>')
+					.css('padding-top', '5px')
 					.css('font-size', 15);
 				$item.append(timeDisplay);
 			}


### PR DESCRIPTION
A few people were confused about what the times meant. What do you think of this as a potential solution to the problem? @TheBox193

<img width="457" alt="screen shot 2016-07-27 at 7 30 32 pm" src="https://cloud.githubusercontent.com/assets/9411156/17197239/a1e6e584-5430-11e6-9208-3e9664a98426.png">
