### PR TITLE
Move delivery time calculations to chrome extension

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,16 @@
+var browserify = require('browserify');
 var gulp = require('gulp');
 var uglify = require('gulp-uglify');
 var rename = require('gulp-rename');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
 var zip = require('gulp-zip');
 
 gulp.task('default', function() {
-	gulp.src('src/diningin.tweaks.js')
+	browserify('src/diningin.tweaks.js')
+	.bundle()
+	.pipe(source('bundle.js'))
+	.pipe(buffer())
 	.pipe(uglify({preserveComments: "some"}))
 	.pipe(rename({
 		suffix: '.min'
@@ -12,6 +18,6 @@ gulp.task('default', function() {
 	.pipe(gulp.dest('src'));
 
 	return gulp.src(['**', '!./node_modules/', '!./node_modules/**', '!./dist/', '!./dist/**'])
-    .pipe(zip('diningin.tweaks.zip'))
+	.pipe(zip('diningin.tweaks.zip'))
 	.pipe(gulp.dest('dist'));
 });

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
 			],
 			"js": [
 				"jquery.js",
-				"/src/diningin.tweaks.js"
+				"/src/bundle.min.js"
 			]
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "gulp-zip": "^3.0.2"
   },
   "dependencies": {
-    "jquery": "^2.1.4"
+    "browserify": "^13.1.0",
+    "jquery": "^2.1.4",
+    "moment": "^2.14.1",
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.1.0"
   }
 }


### PR DESCRIPTION
@TheBox193 
See: https://github.com/steenburgh/diningin-time-tracker/issues/2

I also modified the build process somewhat to make including Moment.js easier. This commit can be removed if necessary + we can just include moment in the .zip file the same way we include jQuery.
